### PR TITLE
:require in ns definition

### DIFF
--- a/src/tamarin/core.clj
+++ b/src/tamarin/core.clj
@@ -1,5 +1,5 @@
 (ns tamarin.core
-  (require [clojure.zip :as z]))
+  (:require [clojure.zip :as z]))
 
 (def t1 {:a {:b [1 2 3] :c "hello"} :d :what?})
 (def t2 {:a [1] :b :hi})


### PR DESCRIPTION
Preparing for clojure 1.9, which throws an error when not using the keyword style of require.